### PR TITLE
Remove Ubuntu 18.04 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
         build_type: [Debug, Release]
         compiler: [clang++-10, clang++-12, g++-11]
         # include:
@@ -27,10 +27,6 @@ jobs:
         #     build_type: Release
         #     compiler: msvc
         exclude:
-          - os: ubuntu-18.04
-            compiler: clang++-12
-          - os: ubuntu-18.04
-            compiler: g++-11
           - os: ubuntu-22.04
             compiler: clang++-10
 


### PR DESCRIPTION
Remove Ubuntu 18.04: https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/