### PR TITLE
Potential fix for code scanning alert no. 15: Array offset used before range check

### DIFF
--- a/test/unit_tests.cpp
+++ b/test/unit_tests.cpp
@@ -463,7 +463,7 @@ int main(int argc, char** argv)
   doctest::Context ctx;
   ctx.applyCommandLine(argc, argv);
   for (size_t i = 0; i < argc; i++)
-    if (strcmp(argv[i], "--data-dir") == 0 && i < argc - 1)
+    if (i < argc - 1 && strcmp(argv[i], "--data-dir") == 0)
       test_data_dir = argv[i + 1];
   return ctx.run();
 }


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/didx509cpp/security/code-scanning/15](https://github.com/microsoft/didx509cpp/security/code-scanning/15)

The best fix is to reorder the `&&` condition so that the range check is evaluated before any array access in that expression.

Specifically in `test/unit_tests.cpp` at line 466, change:

- from: `if (strcmp(argv[i], "--data-dir") == 0 && i < argc - 1)`
- to: `if (i < argc - 1 && strcmp(argv[i], "--data-dir") == 0)`

This preserves behavior (still only sets `test_data_dir` when the flag is found and a following value exists) while satisfying CodeQL’s required safe ordering pattern. No new methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
