### PR TITLE
Explicitly require OpenSSL certificate verification security level 2

### DIFF
--- a/didx509cpp.h
+++ b/didx509cpp.h
@@ -1119,7 +1119,10 @@ namespace didx509
 
         X509_VERIFY_PARAM* param = X509_VERIFY_PARAM_new();
         X509_VERIFY_PARAM_set_depth(param, std::numeric_limits<int>::max());
-        X509_VERIFY_PARAM_set_auth_level(param, 0);
+        // Require at least 112-bit-equivalent security (OpenSSL level 2):
+        // RSA/DSA/DH keys >= 2048 bits, ECC keys >= 224 bits, no RC4 or MD5.
+        // See https://docs.openssl.org/master/man3/SSL_CTX_set_security_level/
+        X509_VERIFY_PARAM_set_auth_level(param, 2);
 
         CHECK1(X509_VERIFY_PARAM_set_flags(param, X509_V_FLAG_X509_STRICT));
         CHECK1(


### PR DESCRIPTION
This PR replaces the old `X509_VERIFY_PARAM_set_auth_level(param, 0)` call (which unconditionally disabled all algorithm-strength checks) with an explicit level 2, and adds an explanatory comment.

## Before
The original code forced auth level 0 since the first prototype. OpenSSL documents that level 0 means "everything is permitted" — all signature algorithms and key sizes pass, including MD5, short RSA keys, etc.

## After
We now explicitly set level 2 with a comment explaining the choice:

```cpp
// Require at least 112-bit-equivalent security (OpenSSL level 2):
// RSA/DSA/DH keys >= 2048 bits, ECC keys >= 224 bits, no RC4 or MD5.
// See https://docs.openssl.org/master/man3/SSL_CTX_set_security_level/
X509_VERIFY_PARAM_set_auth_level(param, 2);
```

## What each level means (from OpenSSL docs)

| Level | Min security | Minimum key sizes | Additional exclusions |
|-------|-------------|-------------------|-----------------------|
| 0 | none | any | none (everything permitted) |
| 1 | 80 bits | RSA/DSA/DH ≥ 1024, ECC ≥ 160 | MD5 MACs, MD5/SHA1 sigs |
| **2** | **112 bits** | **RSA/DSA/DH ≥ 2048, ECC ≥ 224** | **+ RC4, + compression disabled** |
| 3 | 128 bits | RSA/DSA/DH ≥ 3072, ECC ≥ 256 | + no forward-secrecy-less ciphers |
| 4 | 192 bits | RSA/DSA/DH ≥ 7680, ECC ≥ 384 | + SHA1 MACs |
| 5 | 256 bits | RSA/DSA/DH ≥ 15360, ECC ≥ 512 | |

References:
- [`SSL_CTX_set_security_level` — Default Callback Behaviour](https://docs.openssl.org/master/man3/SSL_CTX_set_security_level/#default-callback-behaviour)
- [`X509_VERIFY_PARAM_set_auth_level` — Description](https://docs.openssl.org/master/man3/X509_VERIFY_PARAM_set_flags/#description)

Level 2 is also the OpenSSL 3.x compiled-in default when `-DOPENSSL_TLS_SECURITY_LEVEL` is not overridden at build time (it was 1 in OpenSSL 1.x). Explicitly setting it makes the requirement clear and version-independent.

## Implications
- Certificates with RSA/DSA/DH keys shorter than 2048 bits, or ECC keys shorter than 224 bits, will fail chain verification.
- MD5-signed certificates and RC4-based chains are rejected.
- This is intentional hardening consistent with current best practices (NIST SP800-57).

## Tests
All 33 test cases, 230 assertions pass.