### PR TITLE
Honor the provided roots in UqSTACK_OF_X509::verify()

### DIFF
--- a/didx509cpp.h
+++ b/didx509cpp.h
@@ -1109,7 +1109,7 @@ namespace didx509
 
         for (const auto& c : roots)
         {
-          CHECK1(X509_STORE_add_cert(store, back()));
+          CHECK1(X509_STORE_add_cert(store, c));
         }
 
         auto target = at(0);

--- a/test/unit_tests.cpp
+++ b/test/unit_tests.cpp
@@ -446,6 +446,26 @@ TEST_CASE("TestResolveChainDirectly")
   CHECK(nlohmann::json::parse(valid_chain.front().public_jwk()).contains("kty"));
 }
 
+TEST_CASE("TestVerifyHonorsProvidedRoots")
+{
+  // verify() must anchor trust on the roots it is given, not on the chain's
+  // own last certificate. The loop previously added back() (the chain's last
+  // certificate) for every entry in `roots`, ignoring the provided roots.
+  UqSTACK_OF_X509 chain(load_certificate_chain("ms-code-signing.pem"));
+
+  // A certificate from an unrelated chain that signed nothing in `chain`.
+  UqSTACK_OF_X509 unrelated(load_certificate_chain("fulcio-email.pem"));
+  std::vector<UqX509> roots;
+  roots.emplace_back(unrelated.back());
+
+  // With trust anchored only on the unrelated root, there is no valid path, so
+  // verification must fail. The previous code ignored `roots` and trusted
+  // chain.back(), which made this wrongly succeed.
+  REQUIRE_THROWS_WITH(
+    (void)chain.verify(roots, true),
+    doctest::Contains("certificate chain verification failed"));
+}
+
 TEST_CASE("TestInvalidLeafOnly")
 {
   auto chain = load_certificate_chain("containerplat-leaf.pem");


### PR DESCRIPTION
## Summary

`UqSTACK_OF_X509::verify()` builds an `X509_STORE` of trusted roots from its `roots` parameter:

```cpp
for (const auto& c : roots)
{
  CHECK1(X509_STORE_add_cert(store, back()));  // adds back(), ignores c
}
```

The loop iterates over `roots` but adds `back()` — the **last certificate of the chain being verified** (`*this`) — on every iteration, instead of the current root `c`. The loop variable `c` is unused, so the caller-supplied `roots` are effectively ignored and the chain's own last certificate is used as the trust anchor instead.

## Impact

This is **currently latent**. The only caller, `resolve_chain()`, builds a single-element `roots` vector whose one entry *is* `chain.back()`:

```cpp
UqX509 root = chain.back();
std::vector<UqX509> roots;
roots.emplace_back(std::move(root));
auto valid_chain = chain.verify(roots, ignore_time);
```

so the buggy and correct behaviour coincide for that path. It is, however, a hazard for any other use of this public method:

- with **more than one root**, only `chain.back()` would be added (repeatedly) and the remaining roots ignored;
- a **root that differs from `chain.back()`** would be ignored entirely, while the chain's own last certificate would be trusted as the anchor.

## Fix

Add each provided root `c` to the store:

```cpp
for (const auto& c : roots)
{
  CHECK1(X509_STORE_add_cert(store, c));
}
```

No behavioural change for the existing `resolve_chain()` caller (verified by the unchanged test suite).

## Tests

Adds `TestVerifyHonorsProvidedRoots`: it verifies the `ms-code-signing.pem` chain while supplying an **unrelated** root (a certificate from `fulcio-email.pem` that signed nothing in the chain) and asserts that verification fails.

- **Before** the fix, the unrelated root was ignored and `chain.back()` was trusted, so the call wrongly succeeded — the test fails (`did NOT throw at all`).
- **After** the fix, trust is anchored only on the supplied root, no valid path exists, and verification fails as expected — the test passes.

## Validation

- Full suite passes: **34 cases / 231 assertions**, built with Clang `-fsanitize=address,undefined,leak` (no leaks or UB).
- `clang-tidy didx509cpp.h` is clean (exit 0), matching the CI gate.
