### PR TITLE
Guard to_base64 against empty input (UB on back())

### DIFF
--- a/didx509cpp.h
+++ b/didx509cpp.h
@@ -97,6 +97,13 @@ namespace didx509
 
     inline std::string to_base64(const std::vector<uint8_t>& bytes)
     {
+      // EVP_EncodeBlock produces nothing for empty input; return early so the
+      // padding-trim loop below does not call back() on an empty string (UB).
+      if (bytes.empty())
+      {
+        return {};
+      }
+
       const int r_sz = 4 * ((bytes.size() + 2) / 3);
       std::string r(r_sz, 0);
       auto out_sz =
@@ -105,7 +112,7 @@ namespace didx509
       {
         throw std::runtime_error("base64 conversion failed");
       }
-      while (r.back() == '=')
+      while (!r.empty() && r.back() == '=')
       {
         r.pop_back();
       }

--- a/test/unit_tests.cpp
+++ b/test/unit_tests.cpp
@@ -645,6 +645,12 @@ TEST_CASE("TestEcJwkCoordinatePadding")
   CHECK(x.front() == 0x00);
 }
 
+TEST_CASE("to_base64 and to_base64url empty input")
+{
+  CHECK(to_base64({}) == "");
+  CHECK(to_base64url({}) == "");
+}
+
 int main(int argc, char** argv)
 {
   doctest::Context ctx;


### PR DESCRIPTION
## Summary

`to_base64` trims trailing `=` padding with:

```cpp
while (r.back() == '=') { r.pop_back(); }
```

For an empty input vector, `r_sz` is `0`, `r` is an empty string, and `r.back()` on an empty `std::string` is undefined behaviour.

## Fix

- Return early for empty input (`EVP_EncodeBlock` produces nothing anyway).
- Defensively guard the trim loop with `!r.empty()`.

Currently unreachable — `to_base64` is only ever called on fixed-size hashes and non-empty EC/RSA key components — so this is a hardening fix.

## Testing

- `cmake --build build` — clean.
- `ctest` — all tests pass, including a new regression test covering `to_base64({})` and `to_base64url({})`.
- `clang-tidy ../didx509cpp.h` — exit 0, no findings (mirrors CI).

Found during a security review of the codebase.