### PR TITLE
Make resolved DID document conform to the did:x509 spec

### DIFF
--- a/didx509cpp.h
+++ b/didx509cpp.h
@@ -1669,12 +1669,15 @@ namespace didx509
       const auto& leaf_jwk = leaf.public_jwk();
 
       std::string r = R"({
-    "@context": "https://www.w3.org/ns/did/v1",
+    "@context": [
+        "https://www.w3.org/ns/did/v1",
+        "https://w3id.org/security/suites/jws-2020/v1"
+    ],
     "id": ")" + did_json +
         R"(",
     "verificationMethod": [{
         "id": ")" + did_json +
-        R"(#key-1",
+        R"(#0",
         "type": "JsonWebKey2020",
         "controller": ")" + did_json +
         R"(",
@@ -1684,11 +1687,11 @@ namespace didx509
 
       if (include_assertion_method)
       {
-        r += R"(,"assertionMethod": ")" + did_json + R"(#key-1")";
+        r += R"(,"assertionMethod": [")" + did_json + R"(#0"])";
       }
       if (include_key_agreement)
       {
-        r += R"(,"keyAgreement": ")" + did_json + R"(#key-1")";
+        r += R"(,"keyAgreement": [")" + did_json + R"(#0"])";
       }
 
       r += "\n}";

--- a/test/unit_tests.cpp
+++ b/test/unit_tests.cpp
@@ -57,11 +57,16 @@ void test_resolve_success(const std::string& chain, const std::string& did)
   // Verify that resolved DID document is valid JSON
   nlohmann::json doc;
   REQUIRE_NOTHROW(doc = nlohmann::json::parse(did_doc));
-  CHECK(doc["@context"] == "https://www.w3.org/ns/did/v1");
+  REQUIRE(doc["@context"].is_array());
+  CHECK(
+    doc["@context"] ==
+    nlohmann::json::array(
+      {"https://www.w3.org/ns/did/v1",
+       "https://w3id.org/security/suites/jws-2020/v1"}));
   CHECK(doc["id"] == did);
   REQUIRE(doc["verificationMethod"].is_array());
   REQUIRE(doc["verificationMethod"].size() == 1);
-  CHECK(doc["verificationMethod"][0]["id"] == did + "#key-1");
+  CHECK(doc["verificationMethod"][0]["id"] == did + "#0");
   CHECK(doc["verificationMethod"][0]["type"] == "JsonWebKey2020");
   CHECK(doc["verificationMethod"][0]["controller"] == did);
   CHECK(doc["verificationMethod"][0]["publicKeyJwk"].contains("kty"));
@@ -606,15 +611,15 @@ TEST_CASE("TestDIDDocumentKeyUsageSections")
     "did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE"
     "::subject:CN:Microsoft%20Corporation";
   auto doc = nlohmann::json::parse(resolve(chain, did, true));
-  CHECK(doc["assertionMethod"] == did + "#key-1");
-  CHECK(doc["keyAgreement"] == did + "#key-1");
+  CHECK(doc["assertionMethod"] == nlohmann::json::array({did + "#0"}));
+  CHECK(doc["keyAgreement"] == nlohmann::json::array({did + "#0"}));
 
   chain = load_certificate_chain("dns-san.pem");
   did =
     "did:x509:0:sha256:T1HzOxsDN5SKU6VYKcUFzNVlWiLdxbJ4H7w5WuYcUkM"
     "::san:dns:san-test.example.com";
   doc = nlohmann::json::parse(resolve(chain, did, true));
-  CHECK(doc["assertionMethod"] == did + "#key-1");
+  CHECK(doc["assertionMethod"] == nlohmann::json::array({did + "#0"}));
   CHECK_FALSE(doc.contains("keyAgreement"));
 }
 


### PR DESCRIPTION
## Summary

A thorough consistency check of the resolver against the [did:x509 specification](https://github.com/microsoft/did-x509/blob/main/specification.md) found that the DID document produced by `create_did_document()` deviated from the spec's Read operation (steps 9–11) in three ways. This PR aligns the output with the spec; the predicate/verification logic is unchanged.

## Changes

1. **`@context` is now an array** (spec step 9):
   ```json
   ["https://www.w3.org/ns/did/v1",
    "https://w3id.org/security/suites/jws-2020/v1"]
   ```
   Previously a single string `"https://www.w3.org/ns/did/v1"`. The old value omitted the `jws-2020/v1` context that *defines* the `JsonWebKey2020` verification-method type the document uses, so the output was not valid JSON-LD.

2. **Verification method id fragment is now `#0`** (spec step 9) instead of `#key-1`.

3. **`assertionMethod` / `keyAgreement` are now arrays** `["<DID>#0"]` (spec steps 10–11) instead of bare strings.

The key-usage logic that decides whether to emit `assertionMethod` and/or `keyAgreement` (spec steps 10–12) is unchanged.

### Before / after

```diff
-    "@context": "https://www.w3.org/ns/did/v1",
+    "@context": [
+        "https://www.w3.org/ns/did/v1",
+        "https://w3id.org/security/suites/jws-2020/v1"
+    ],
...
-        "id": "<DID>#key-1",
+        "id": "<DID>#0",
...
-    "assertionMethod": "<DID>#key-1","keyAgreement": "<DID>#key-1"
+    "assertionMethod": ["<DID>#0"],"keyAgreement": ["<DID>#0"]
```

## Out of scope

Other items surfaced by the consistency check are intentionally not addressed here:
- The Read step 2 "critical extension" rule is deliberately delegated to OpenSSL path validation, as documented in `critical-extensions-spec-clarification.md` ("not intended to be merged").
- Minor DID-prefix parser strictness and repeated-subject-attribute edge cases (spec-undefined / negligible).

## Testing

- Updated the four affected assertions in `test/unit_tests.cpp`.
- `cmake --build build && ctest` — all unit tests pass.
- Verified the resolved documents parse as valid JSON for both the dual key-usage (`assertionMethod` + `keyAgreement`) and `digitalSignature`-only cases.