### PR TITLE
Bump CodeQL actions to v4.37.6

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         languages: ${{ matrix.language }}
         queries: security-extended
@@ -53,4 +53,4 @@ jobs:
       run: cmake --build . --config Debug
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6


### PR DESCRIPTION
## Summary
- update `github/codeql-action/init` from v4.37.3 to v4.37.6
- update `github/codeql-action/analyze` from v4.37.3 to v4.37.6
- retain immutable full-SHA pinning

## Validation
- confirmed the v4.37.6 tag resolves to `5595ccaf912efad79be6eef63a5619ff05969be3`
- checked the workflow diff for whitespace errors