### PR TITLE
Add CMake-integrated clang-tidy CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,7 +21,6 @@ Checks: >
   -bugprone-easily-swappable-parameters,
   -bugprone-narrowing-conversions,
   -cppcoreguidelines-narrowing-conversions,
-  -readability-function-cognitive-complexity,
   -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
   -cppcoreguidelines-avoid-magic-numbers,
   -readability-magic-numbers,
@@ -37,7 +36,10 @@ Checks: >
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,
   -cppcoreguidelines-pro-type-union-access
 
-
 WarningsAsErrors: '*'
-HeaderFilterRegex: '.*didx509cpp\.h'
+HeaderFilterRegex: '(^|.*/)didx509cpp\.h$'
 FormatStyle:     'file'
+
+CheckOptions:
+  readability-function-cognitive-complexity.IgnoreMacros: true
+  readability-function-cognitive-complexity.Threshold: 100

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_CXX_COMPILER=clang++-18 \
             -DCLANG_TIDY=ON \
-            -DTESTS=OFF
+            -DTESTS=ON
 
       - name: Run clang-tidy
         run: cmake --build build/clang-tidy --target clang-tidy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,29 @@ jobs:
         shell: bash
         run: ctest -C ${{ matrix.build_type }} -VV
 
+  clang-tidy:
+    name: Clang-Tidy
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Install packages
+        run: |
+          sudo apt update
+          sudo apt install clang-18 clang-tidy-18 libcurl4-openssl-dev libssl-dev
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Configure CMake
+        run: |
+          cmake -S . -B build/clang-tidy \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_CXX_COMPILER=clang++-18 \
+            -DCLANG_TIDY=ON \
+            -DTESTS=OFF
+
+      - name: Run clang-tidy
+        run: cmake --build build/clang-tidy --target clang-tidy
+
   build-test-azure-linux:
     runs-on: ubuntu-latest
     container:
@@ -103,11 +126,6 @@ jobs:
         working-directory: build/${{ matrix.build_type }}
         shell: bash
         run: cmake --build . --config ${{ matrix.build_type }}
-
-      - name: Clang-Tidy
-        working-directory: build/${{ matrix.build_type }}
-        shell: bash
-        run: clang-tidy ../../didx509cpp.h
 
       - name: Test
         working-directory: build/${{ matrix.build_type }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,28 +57,7 @@ if(TESTS)
     target_link_libraries(${NAME} PRIVATE $<BUILD_INTERFACE:didx509cpp>)
 
     if(CLANG_TIDY)
-      # Establish test coverage without making pre-existing test-only findings
-      # block adoption. Library diagnostics remain governed by .clang-tidy.
-      string(
-        CONCAT
-        TEST_CLANG_TIDY_EXCLUSIONS
-        "-clang-analyzer-cplusplus.NewDeleteLeaks"
-        ",-cppcoreguidelines-avoid-non-const-global-variables"
-        ",-cppcoreguidelines-pro-type-reinterpret-cast"
-        ",-misc-const-correctness"
-        ",-misc-include-cleaner"
-        ",-misc-use-anonymous-namespace"
-        ",-modernize-use-auto"
-        ",-modernize-use-emplace"
-        ",-readability-braces-around-statements"
-        ",-readability-qualified-auto"
-      )
-      set_property(
-        TARGET ${NAME}
-        PROPERTY
-          CXX_CLANG_TIDY
-          "${CLANG_TIDY_EXE};--checks=${TEST_CLANG_TIDY_EXCLUSIONS}"
-      )
+      enable_clang_tidy(${NAME})
       add_dependencies(clang-tidy ${NAME})
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,14 +34,19 @@ if(CLANG_TIDY)
 
   message(STATUS "Using clang-tidy from: ${CLANG_TIDY_EXE}")
 
+  function(enable_clang_tidy TARGET)
+    set_property(
+      TARGET ${TARGET}
+      PROPERTY CXX_CLANG_TIDY "${CLANG_TIDY_EXE}"
+    )
+  endfunction()
+
   # Compile a minimal translation unit so clang-tidy can check this header-only
   # library without reporting findings from the unit test implementation.
-  add_library(clang-tidy OBJECT test/clang_tidy.cpp)
-  target_link_libraries(clang-tidy PRIVATE didx509cpp)
-  set_property(
-    TARGET clang-tidy
-    PROPERTY CXX_CLANG_TIDY "${CLANG_TIDY_EXE}"
-  )
+  add_library(clang-tidy-library OBJECT test/clang_tidy.cpp)
+  target_link_libraries(clang-tidy-library PRIVATE didx509cpp)
+  enable_clang_tidy(clang-tidy-library)
+  add_custom_target(clang-tidy DEPENDS clang-tidy-library)
 endif()
 
 if(TESTS)
@@ -50,6 +55,32 @@ if(TESTS)
   function(add_unit_test NAME SRC)
     add_executable(${NAME} ${SRC})
     target_link_libraries(${NAME} PRIVATE $<BUILD_INTERFACE:didx509cpp>)
+
+    if(CLANG_TIDY)
+      # Establish test coverage without making pre-existing test-only findings
+      # block adoption. Library diagnostics remain governed by .clang-tidy.
+      string(
+        CONCAT
+        TEST_CLANG_TIDY_EXCLUSIONS
+        "-clang-analyzer-cplusplus.NewDeleteLeaks"
+        ",-cppcoreguidelines-avoid-non-const-global-variables"
+        ",-cppcoreguidelines-pro-type-reinterpret-cast"
+        ",-misc-const-correctness"
+        ",-misc-include-cleaner"
+        ",-misc-use-anonymous-namespace"
+        ",-modernize-use-auto"
+        ",-modernize-use-emplace"
+        ",-readability-braces-around-statements"
+        ",-readability-qualified-auto"
+      )
+      set_property(
+        TARGET ${NAME}
+        PROPERTY
+          CXX_CLANG_TIDY
+          "${CLANG_TIDY_EXE};--checks=${TEST_CLANG_TIDY_EXCLUSIONS}"
+      )
+      add_dependencies(clang-tidy ${NAME})
+    endif()
 
     if(PROFILE)
       target_compile_options(${NAME} PRIVATE -g -pg)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ set(CMAKE_CXX_STANDARD 20)
 
 option(PROFILE "enable profiling" OFF)
 option(TESTS "enable testing" ON)
+option(CLANG_TIDY "run clang-tidy on the codebase" OFF)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_library(didx509cpp INTERFACE)
 target_include_directories(didx509cpp INTERFACE .)
@@ -19,6 +22,27 @@ set(CMAKE_FIND_LIBRARY_SUFFIXES ".a" ".so")
 find_package(OpenSSL)
 target_compile_definitions(didx509cpp INTERFACE HAVE_OPENSSL)
 target_link_libraries(didx509cpp INTERFACE crypto)
+
+if(CLANG_TIDY)
+  find_program(
+    CLANG_TIDY_EXE
+    NAMES clang-tidy-18 clang-tidy
+  )
+  if(NOT CLANG_TIDY_EXE)
+    message(FATAL_ERROR "CLANG_TIDY is ON, but clang-tidy was not found")
+  endif()
+
+  message(STATUS "Using clang-tidy from: ${CLANG_TIDY_EXE}")
+
+  # Compile a minimal translation unit so clang-tidy can check this header-only
+  # library without reporting findings from the unit test implementation.
+  add_library(clang-tidy OBJECT test/clang_tidy.cpp)
+  target_link_libraries(clang-tidy PRIVATE didx509cpp)
+  set_property(
+    TARGET clang-tidy
+    PROPERTY CXX_CLANG_TIDY "${CLANG_TIDY_EXE}"
+  )
+endif()
 
 if(TESTS)
   enable_testing()

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ target:
 cmake -S . -B build/clang-tidy \
   -DCMAKE_CXX_COMPILER=clang++-18 \
   -DCLANG_TIDY=ON \
-  -DTESTS=OFF
+  -DTESTS=ON
 cmake --build build/clang-tidy --target clang-tidy
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ try {
 
 ## Contributing
 
+To run clang-tidy locally, configure with Clang 18 and enable the opt-in
+target:
+
+```bash
+cmake -S . -B build/clang-tidy \
+  -DCMAKE_CXX_COMPILER=clang++-18 \
+  -DCLANG_TIDY=ON \
+  -DTESTS=OFF
+cmake --build build/clang-tidy --target clang-tidy
+```
+
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
 the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,3 +4,4 @@
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_unit_test(unit_tests unit_tests.cpp --data-dir ${CMAKE_CURRENT_SOURCE_DIR}/test-data)
+target_include_directories(unit_tests SYSTEM PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/clang_tidy.cpp
+++ b/test/clang_tidy.cpp
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "didx509cpp.h"
+
+static_assert(&didx509::resolve != nullptr);

--- a/test/doctest.h
+++ b/test/doctest.h
@@ -3579,7 +3579,7 @@ String::String() noexcept {
 }
 
 String::~String() {
-    if(!isOnStack())
+    if(!isOnStack()) // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
         delete[] data.ptr;
 } // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 

--- a/test/unit_tests.cpp
+++ b/test/unit_tests.cpp
@@ -3,33 +3,50 @@
 
 #include "didx509cpp.h"
 
-#include <openssl/evp.h>
-
 #include <algorithm>
+#include <bit>
+#include <cctype>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <openssl/evp.h>
+#include <sstream>
+#include <stdexcept>
 #include <string>
+#include <string_view>
+#include <vector>
 
 #define DOCTEST_CONFIG_IMPLEMENT
-#include "doctest.h"
-#include "json.hpp"
+#include <doctest.h>
+#include <json.hpp>
 
 using namespace didx509;
 
-static std::string test_data_dir = "../test/test-data";
-
-static std::string load_certificate_chain(const std::string& path)
+namespace
 {
-  std::ifstream t(test_data_dir + "/" + path);
+std::string& test_data_dir()
+{
+  static std::string path = "../test/test-data";
+  return path;
+}
+
+std::string load_certificate_chain(const std::string& path)
+{
+  std::ifstream const t(test_data_dir() + "/" + path);
   if (!t.good())
+  {
     throw std::runtime_error(std::string("could not open ") + path);
+  }
   std::stringstream ss;
   ss << t.rdbuf();
   return ss.str();
 }
 
-static std::vector<std::string> split_x509_cert_bundle(
+std::vector<std::string> split_x509_cert_bundle(
   const std::string_view& pem)
 {
-  std::string separator("-----END CERTIFICATE-----");
+  std::string const separator("-----END CERTIFICATE-----");
   std::vector<std::string> pems;
   size_t separator_end = 0;
   auto next_separator_start = pem.find(separator);
@@ -41,9 +58,9 @@ static std::vector<std::string> split_x509_cert_bundle(
     {
       ++separator_end;
     }
-    pems.emplace_back(std::string(pem.substr(
+    pems.emplace_back(pem.substr(
       separator_end,
-      (next_separator_start - separator_end) + separator.size())));
+      (next_separator_start - separator_end) + separator.size()));
     separator_end = next_separator_start + separator.size();
     next_separator_start = pem.find(separator, separator_end);
   }
@@ -85,7 +102,8 @@ void test_resolve_error(
   const std::string& did,
   const doctest::String& error_msg)
 {
-  REQUIRE_THROWS_WITH(resolve(chain, did, true), doctest::Contains(error_msg));
+  REQUIRE_THROWS_WITH( // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+    resolve(chain, did, true), doctest::Contains(error_msg));
 }
 
 void test_resolve_jwk_error(
@@ -93,35 +111,39 @@ void test_resolve_jwk_error(
   const std::string& did,
   const doctest::String& error_msg)
 {
-  REQUIRE_THROWS_WITH(resolve_jwk(chain, did, true), doctest::Contains(error_msg));
+  REQUIRE_THROWS_WITH( // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+    resolve_jwk(chain, did, true), doctest::Contains(error_msg));
 }
 
+// doctest::String's manual small-string optimization triggers analyzer leak
+// false positives at some assertion sites. Keep suppressions on those exact
+// diagnostics rather than disabling the check for the test target.
 TEST_CASE("Wrong prefix")
 {
   auto chain = load_certificate_chain("ms-code-signing.pem");
-  auto did = "djd:y508:1:abcd::";
+  const auto* did = "djd:y508:1:abcd::";
   test_resolve_error(chain, did, "unsupported method/prefix");
-}
+} // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
 TEST_CASE("Empty chain")
 {
-  auto chain = "";
-  auto did = "djd:y508:1:abcd::";
+  const auto* chain = "";
+  const auto* did = "djd:y508:1:abcd::";
   test_resolve_error(chain, did, "no certificate chain");
 }
 
 TEST_CASE("Chain of one not-a-cert-but-a-chain")
 {
   auto chain = load_certificate_chain("ms-code-signing.pem");
-  auto did =
+  const auto* did =
     "did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE"
     "::subject:CN:Microsoft%20Corporation";
   test_resolve_jwk_error({chain}, did, "expected exactly one PEM element");
-}
+} // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
 TEST_CASE("Invalid input")
 {
-  auto did =
+  const auto* did =
     "did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE"
     "::subject:CN:Microsoft%20Corporation";
   test_resolve_jwk_error({"-----BEGIN CERTIFICATE-----"}, did, "bad end line");
@@ -131,12 +153,12 @@ TEST_CASE("Invalid input")
   test_resolve_jwk_error(split_chain, did, "bad base64 decode");
   split_chain[0][42] -= 10;
   test_resolve_jwk_error(split_chain, did, "asn1 encoding routines::too long");
-}
+} // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
 TEST_CASE("TestRootCA")
 {
   auto chain = load_certificate_chain("ms-code-signing.pem");
-  auto did =
+  const auto* did =
     "did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE"
     "::subject:CN:Microsoft%20Corporation";
   test_resolve_success(chain, did);
@@ -145,7 +167,7 @@ TEST_CASE("TestRootCA")
 TEST_CASE("TestIntermediateCA")
 {
   auto chain = load_certificate_chain("ms-code-signing.pem");
-  auto did =
+  const auto* did =
     "did:x509:0:sha256:VtqHIq_ZQGb_4eRZVHOkhUiSuEOggn1T-32PSu7R4Ys"
     "::subject:CN:Microsoft%20Corporation";
   test_resolve_success(chain, did);
@@ -154,22 +176,23 @@ TEST_CASE("TestIntermediateCA")
 TEST_CASE("TestInvalidLeafCA")
 {
   auto chain = load_certificate_chain("ms-code-signing.pem");
-  auto did = "did:x509:0:sha256:h::subject:CN:Microsoft%20Corporation";
+  const auto* did = "did:x509:0:sha256:h::subject:CN:Microsoft%20Corporation";
   test_resolve_error(chain, did, "invalid certificate fingerprint");
-}
+} // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
 TEST_CASE("TestInvalidCA")
 {
   auto chain = load_certificate_chain("ms-code-signing.pem");
-  auto did = "did:x509:0:sha256:abc::CN:Microsoft%20Corporation";
+  const auto* did = "did:x509:0:sha256:abc::CN:Microsoft%20Corporation";
   test_resolve_error(chain, did, "invalid certificate fingerprint");
-}
+} // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
 TEST_CASE("TestFingerprintAlgorithms")
 {
   auto chain = load_certificate_chain("ms-code-signing.pem");
-  auto did =
-    "did:x509:0:sha384:tg8BQvQznAnlqwHWedNqMSKxsf-_dDmEB7qsgYP0eamWeA5M5UNdgPQWMtCdWkoz"
+  const auto* did =
+    "did:x509:0:sha384:tg8BQvQznAnlqwHWedNqMSKxsf-_"
+    "dDmEB7qsgYP0eamWeA5M5UNdgPQWMtCdWkoz"
     "::subject:CN:Microsoft%20Corporation";
   test_resolve_success(chain, did);
 
@@ -182,16 +205,16 @@ TEST_CASE("TestFingerprintAlgorithms")
 TEST_CASE("TestUnsupportedFingerprintAlgorithm")
 {
   auto chain = load_certificate_chain("ms-code-signing.pem");
-  auto did =
+  const auto* did =
     "did:x509:0:sha1:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE"
     "::subject:CN:Microsoft%20Corporation";
   test_resolve_error(chain, did, "unsupported fingerprint algorithm");
-}
+} // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
 TEST_CASE("TestMultiplePolicies")
 {
   auto chain = load_certificate_chain("ms-code-signing.pem");
-  auto did =
+  const auto* did =
     "did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE"
     "::eku:1.3.6.1.5.5.7.3.3"
     "::eku:1.3.6.1.4.1.311.10.3.21";
@@ -201,7 +224,7 @@ TEST_CASE("TestMultiplePolicies")
 TEST_CASE("TestSubject")
 {
   auto chain = load_certificate_chain("ms-code-signing.pem");
-  auto did =
+  const auto* did =
     "did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE"
     "::subject:CN:Microsoft%20Corporation";
   test_resolve_success(chain, did);
@@ -210,7 +233,7 @@ TEST_CASE("TestSubject")
 TEST_CASE("TestSubjectWithStateST")
 {
   auto chain = load_certificate_chain("ms-code-signing.pem");
-  auto did =
+  const auto* did =
     "did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE"
     "::subject:CN:Microsoft%20Corporation:ST:Washington";
   test_resolve_success(chain, did);
@@ -225,7 +248,7 @@ TEST_CASE("TestSubjectWithStateST")
 TEST_CASE("TestSubjectWithStateS")
 {
   auto chain = load_certificate_chain("ms-code-signing.pem");
-  auto did =
+  const auto* did =
     "did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE"
     "::subject:CN:Microsoft%20Corporation:S:Washington";
   test_resolve_success(chain, did);
@@ -240,7 +263,7 @@ TEST_CASE("TestSubjectWithStateS")
 TEST_CASE("TestSubjectWithStateSandST")
 {
   auto chain = load_certificate_chain("ms-code-signing.pem");
-  auto did =
+  const auto* did =
     "did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE"
     "::subject:CN:Microsoft%20Corporation:S:Washington:ST:Washington";
   test_resolve_error(chain, did, "duplicate field 'ST'");
@@ -253,16 +276,16 @@ TEST_CASE("TestSubjectWithStateSandST")
 TEST_CASE("TestSubjectInvalidName")
 {
   auto chain = load_certificate_chain("ms-code-signing.pem");
-  auto did =
+  const auto* did =
     "did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE"
     "::subject:CN:MicrosoftCorporation";
   test_resolve_error(chain, did, "invalid subject key/value");
-}
+} // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
 TEST_CASE("TestSubjectDuplicateField")
 {
   auto chain = load_certificate_chain("ms-code-signing.pem");
-  auto did =
+  const auto* did =
     "did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE"
     "::subject:CN:Microsoft%20Corporation:CN:Microsoft%20Corporation";
   test_resolve_error(chain, did, "duplicate field");
@@ -283,20 +306,20 @@ TEST_CASE("TestSubjectExactMatchRequired")
     chain, base + "::subject:CN:Microsoft", "invalid subject key/value");
   // Single-character substring of CN.
   test_resolve_error(
-    chain, base + "::subject:CN:M", "invalid subject key/value");
+    chain, base + "::subject:CN:M", "invalid subject key/value"); // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
   // Suffix substring of CN.
   test_resolve_error(
-    chain, base + "::subject:CN:Corporation", "invalid subject key/value");
+    chain, base + "::subject:CN:Corporation", "invalid subject key/value"); // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
   // Interior substring of CN (with the space percent-encoded).
   test_resolve_error(
-    chain, base + "::subject:CN:soft%20Corp", "invalid subject key/value");
+    chain, base + "::subject:CN:soft%20Corp", "invalid subject key/value"); // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
   // Substring of the O attribute.
   test_resolve_error(
-    chain, base + "::subject:O:Micro", "invalid subject key/value");
+    chain, base + "::subject:O:Micro", "invalid subject key/value"); // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
   // The exact, complete value still resolves.
   test_resolve_success(
-    chain, base + "::subject:CN:Microsoft%20Corporation");
+    chain, base + "::subject:CN:Microsoft%20Corporation"); // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 }
 
 TEST_CASE("TestSubjectUtf8Value")
@@ -320,7 +343,7 @@ TEST_CASE("TestSubjectUtf8Value")
 
   // The ASCII CN matches exactly.
   test_resolve_success(
-    chain, base + "::subject:CN:didx509cpp%20UTF8%20Test%20Leaf");
+    chain, base + "::subject:CN:didx509cpp%20UTF8%20Test%20Leaf"); // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 }
 
 TEST_CASE("TestSubjectCustomOid")
@@ -349,13 +372,14 @@ TEST_CASE("TestSubjectCustomOid")
   // Standard CN attribute still resolves (positive control).
   test_resolve_success(
     chain,
-    base + "::subject:CN:didx509cpp%20Custom%20OID%20Test%20Leaf");
+    base + "::subject:CN:didx509cpp%20Custom%20OID%20Test%20Leaf"); // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 }
 
 TEST_CASE("TestDIDParserErrors")
 {
   auto chain = load_certificate_chain("ms-code-signing.pem");
-  auto did = "did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE";
+  const auto* did =
+    "did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE";
   test_resolve_error(chain, did, "invalid DID string");
 
   did =
@@ -363,7 +387,7 @@ TEST_CASE("TestDIDParserErrors")
     "::subject:CN:Microsoft%20Corporation";
   test_resolve_error(chain, did, "unsupported did:x509 version");
 
-  did =
+  did = // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
     "did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE"
     "::subject";
   test_resolve_error(chain, did, "invalid policy");
@@ -373,7 +397,7 @@ TEST_CASE("TestDIDParserErrors")
     "::subject:CN";
   test_resolve_error(chain, did, "key-value pairs required");
 
-  did =
+  did = // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
     "did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE"
     "::subject:DC:example";
   test_resolve_error(chain, did, "unsupported subject key");
@@ -383,21 +407,21 @@ TEST_CASE("TestDIDParserErrors")
     "::san:email";
   test_resolve_error(chain, did, "exactly one SAN type and value required");
 
-  did =
+  did = // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
     "did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE"
     "::eku:1.2.3:1.2.4";
   test_resolve_error(chain, did, "exactly one EKU required");
 
-  did =
+  did = // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
     "did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE"
     "::fulcio-issuer:issuer:extra";
   test_resolve_error(chain, did, "excessive arguments to fulcio-issuer");
-}
+} // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
 TEST_CASE("TestSAN")
 {
   auto chain = load_certificate_chain("fulcio-email.pem");
-  auto did =
+  const auto* did =
     "did:x509:0:sha256:O6e2zE6VRp1NM0tJyyV62FNwdvqEsMqH_07P5qVGgME"
     "::san:email:igarcia%40suse.com";
   test_resolve_success(chain, did);
@@ -406,7 +430,7 @@ TEST_CASE("TestSAN")
 TEST_CASE("TestSANInvalidType")
 {
   auto chain = load_certificate_chain("fulcio-email.pem");
-  auto did =
+  const auto* did =
     "did:x509:0:sha256:O6e2zE6VRp1NM0tJyyV62FNwdvqEsMqH_07P5qVGgME"
     "::san:uri:igarcia%40suse.com";
   test_resolve_error(chain, did, "SAN not found");
@@ -415,16 +439,16 @@ TEST_CASE("TestSANInvalidType")
 TEST_CASE("TestSANInvalidValue")
 {
   auto chain = load_certificate_chain("fulcio-email.pem");
-  auto did =
+  const auto* did =
     "did:x509:0:sha256:O6e2zE6VRp1NM0tJyyV62FNwdvqEsMqH_07P5qVGgME"
     "::email:bob%40example.com";
   test_resolve_error(chain, did, "unsupported did:x509 scheme");
-}
+} // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
 TEST_CASE("TestSANWithDns")
 {
   auto chain = load_certificate_chain("dns-san.pem");
-  auto did =
+  const auto* did =
     "did:x509:0:sha256:T1HzOxsDN5SKU6VYKcUFzNVlWiLdxbJ4H7w5WuYcUkM"
     "::san:dns:san-test.example.com";
   test_resolve_success(chain, did);
@@ -433,16 +457,16 @@ TEST_CASE("TestSANWithDns")
 TEST_CASE("TestSANWithIpAddressRejected")
 {
   auto chain = load_certificate_chain("dns-san.pem");
-  auto did =
+  const auto* did =
     "did:x509:0:sha256:T1HzOxsDN5SKU6VYKcUFzNVlWiLdxbJ4H7w5WuYcUkM"
     "::san:ipaddress:127.0.0.1";
   test_resolve_error(chain, did, "unknown SAN type: ipaddress");
-}
+} // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
 TEST_CASE("TestSANUnknownType")
 {
   auto chain = load_certificate_chain("dns-san.pem");
-  auto did =
+  const auto* did =
     "did:x509:0:sha256:T1HzOxsDN5SKU6VYKcUFzNVlWiLdxbJ4H7w5WuYcUkM"
     "::san:other:value";
   test_resolve_error(chain, did, "unknown SAN type");
@@ -495,7 +519,7 @@ TEST_CASE("TestCNEmbeddedNulNotTruncated")
   // NUL-terminated C string.  A certificate whose CN is "trusted\0evil" must
   // NOT compare equal to "trusted" (no truncation at the NUL), and MUST
   // compare equal to the full value including the NUL.
-  UqX509 cert(load_certificate_chain("cn-embedded-nul.pem"));
+  UqX509 const cert(load_certificate_chain("cn-embedded-nul.pem"));
 
   // The prefix before the NUL must not match (no truncation at the NUL).
   CHECK_FALSE(cert.has_common_name("trusted"));
@@ -512,7 +536,7 @@ TEST_CASE("TestCNUtf8Value")
   // The certificate has CN = "café Test", a non-ASCII UTF-8 value stored as
   // a UTF8String.  has_common_name() must decode it correctly via
   // ASN1_STRING_to_UTF8 rather than treating it as raw bytes.
-  UqX509 cert(load_certificate_chain("cn-utf8.pem"));
+  UqX509 const cert(load_certificate_chain("cn-utf8.pem"));
 
   // Exact UTF-8 value must match.
   CHECK(cert.has_common_name("caf\xc3\xa9 Test"));
@@ -548,7 +572,7 @@ TEST_CASE("TestSANNoSubjectFallback")
 TEST_CASE("TestBadEKU")
 {
   auto chain = load_certificate_chain("ms-code-signing.pem");
-  auto did =
+  const auto* did =
     "did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE"
     "::eku:1.3.6.1.5.5.7.3.12";
   test_resolve_error(chain, did, "EKU not found");
@@ -557,7 +581,7 @@ TEST_CASE("TestBadEKU")
 TEST_CASE("TestGoodEKU")
 {
   auto chain = load_certificate_chain("ms-code-signing.pem");
-  auto did =
+  const auto* did =
     "did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE"
     "::eku:1.3.6.1.4.1.311.10.3.21";
   test_resolve_success(chain, did);
@@ -566,7 +590,7 @@ TEST_CASE("TestGoodEKU")
 TEST_CASE("TestEKUInvalidValue")
 {
   auto chain = load_certificate_chain("ms-code-signing.pem");
-  auto did =
+  const auto* did =
     "did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE"
     "::eku:1.2.3";
   test_resolve_error(chain, did, "EKU not found");
@@ -575,7 +599,7 @@ TEST_CASE("TestEKUInvalidValue")
 TEST_CASE("TestFulcioIssuerWithEmailSAN")
 {
   auto chain = load_certificate_chain("fulcio-email.pem");
-  auto did =
+  const auto* did =
     "did:x509:0:sha256:O6e2zE6VRp1NM0tJyyV62FNwdvqEsMqH_07P5qVGgME"
     "::fulcio-issuer:github.com%2Flogin%2Foauth"
     "::san:email:igarcia%40suse.com";
@@ -585,7 +609,7 @@ TEST_CASE("TestFulcioIssuerWithEmailSAN")
 TEST_CASE("TestFulcioIssuerWithURISAN")
 {
   auto chain = load_certificate_chain("fulcio-github-actions.pem");
-  auto did =
+  const auto* did =
     "did:x509:0:sha256:O6e2zE6VRp1NM0tJyyV62FNwdvqEsMqH_07P5qVGgME"
     "::fulcio-issuer:token.actions.githubusercontent.com"
     "::san:uri:https%3A%2F%2Fgithub.com%2Fbrendancassells%2Fmcw-continuous-"
@@ -597,7 +621,7 @@ TEST_CASE("TestFulcioIssuerWithURISAN")
 TEST_CASE("TestInvalidFulcioIssuer")
 {
   auto chain = load_certificate_chain("fulcio-email.pem");
-  auto did =
+  const auto* did =
     "did:x509:0:sha256:O6e2zE6VRp1NM0tJyyV62FNwdvqEsMqH_07P5qVGgME"
     "::fulcio-issuer:example.com"
     "::san:email:igarcia%40suse.com";
@@ -626,8 +650,8 @@ TEST_CASE("TestDIDDocumentKeyUsageSections")
 TEST_CASE("TestResolveChainDirectly")
 {
   auto chain_pem = load_certificate_chain("ms-code-signing.pem");
-  UqSTACK_OF_X509 chain(chain_pem);
-  auto did =
+  UqSTACK_OF_X509 const chain(chain_pem);
+  const auto* did =
     "did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE"
     "::subject:CN:Microsoft%20Corporation";
   auto valid_chain = resolve_chain(chain, did, true);
@@ -640,10 +664,10 @@ TEST_CASE("TestVerifyHonorsProvidedRoots")
   // verify() must anchor trust on the roots it is given, not on the chain's
   // own last certificate. The loop previously added back() (the chain's last
   // certificate) for every entry in `roots`, ignoring the provided roots.
-  UqSTACK_OF_X509 chain(load_certificate_chain("ms-code-signing.pem"));
+  UqSTACK_OF_X509 const chain(load_certificate_chain("ms-code-signing.pem"));
 
   // A certificate from an unrelated chain that signed nothing in `chain`.
-  UqSTACK_OF_X509 unrelated(load_certificate_chain("fulcio-email.pem"));
+  UqSTACK_OF_X509 const unrelated(load_certificate_chain("fulcio-email.pem"));
   std::vector<UqX509> roots;
   roots.emplace_back(unrelated.back());
 
@@ -667,7 +691,7 @@ TEST_CASE("TestInvalidLeafOnly")
     doctest::Contains("certificate chain too short"));
 }
 
-static std::vector<uint8_t> base64url_decode(const std::string& in)
+std::vector<uint8_t> base64url_decode(const std::string& in)
 {
   std::string b64 = in;
   std::replace(b64.begin(), b64.end(), '-', '+');
@@ -677,14 +701,18 @@ static std::vector<uint8_t> base64url_decode(const std::string& in)
 
   std::vector<uint8_t> out((b64.size() / 4) * 3);
   const int decoded_len = EVP_DecodeBlock(out.data(),
-    reinterpret_cast<const unsigned char*>(b64.data()),
+    std::bit_cast<const unsigned char*>(b64.data()),
     static_cast<int>(b64.size()));
   if (decoded_len < 0)
+  {
     return {};
+  }
 
-  size_t out_len = static_cast<size_t>(decoded_len);
+  auto out_len = static_cast<size_t>(decoded_len);
   if (pad <= out_len)
+  {
     out_len -= pad;
+  }
   out.resize(out_len);
   return out;
 }
@@ -696,7 +724,7 @@ TEST_CASE("TestEcJwkCoordinatePadding")
   // 32-octet field element, so the JWK must left-pad them rather than emit the
   // minimal (31-octet) big-endian integer encoding.
   auto chain = load_certificate_chain("ec-leading-zero.pem");
-  auto did =
+  const auto* did =
     "did:x509:0:sha256:SGI1ucfnPQ6_Rx2YIurUyv75tHSapBv2_aiXaGtxP8w"
     "::subject:CN:didx509cpp%20EC%20Test%20Leaf";
 
@@ -718,13 +746,18 @@ TEST_CASE("to_base64 and to_base64url empty input")
   CHECK(to_base64({}) == "");
   CHECK(to_base64url({}) == "");
 }
+}
 
 int main(int argc, char** argv)
 {
   doctest::Context ctx;
   ctx.applyCommandLine(argc, argv);
   for (size_t i = 0; i < argc; i++)
+  {
     if (i < argc - 1 && strcmp(argv[i], "--data-dir") == 0)
-      test_data_dir = argv[i + 1];
+    {
+      test_data_dir() = argv[i + 1];
+    }
+  }
   return ctx.run();
 }

--- a/test/unit_tests.cpp
+++ b/test/unit_tests.cpp
@@ -115,9 +115,11 @@ void test_resolve_jwk_error(
     resolve_jwk(chain, did, true), doctest::Contains(error_msg));
 }
 
-// doctest::String's manual small-string optimization triggers analyzer leak
-// false positives at some assertion sites. Keep suppressions on those exact
-// diagnostics rather than disabling the check for the test target.
+// Clang's path-sensitive analyzer reports false leaks for assertions whose
+// doctest diagnostic strings use heap storage: it does not connect the
+// allocation in doctest::String's small-string optimization with the matching
+// delete in its destructor. Keep suppressions on the reported assertion paths
+// rather than disabling the check for the test target.
 TEST_CASE("Wrong prefix")
 {
   auto chain = load_certificate_chain("ms-code-signing.pem");


### PR DESCRIPTION
## Summary

- add an opt-in `CLANG_TIDY` CMake configuration that discovers Clang-Tidy and fails clearly when unavailable
- lint the header-only library through a minimal translation unit and exported compile commands
- run the same warning-as-error clang-tidy policy on unit-test targets and fix the existing test findings
- replace the ad-hoc Azure Linux invocation with a dedicated Ubuntu 24.04 / Clang 18 CI job
- refine the checked-in policy and document the local command

The CMake option, tool discovery, target property, and CI build integration follow the approach used by [microsoft/CCF](https://github.com/microsoft/CCF/blob/main/CMakeLists.txt) and its [CI workflow](https://github.com/microsoft/CCF/blob/main/.github/workflows/ci.yml), adapted for this repository's header-only layout.

The Clang analyzer cannot model doctest's manual `String` small-string optimization and reports its internal `data.ptr` as leaked. Those confirmed framework false positives are suppressed only at their exact reported source locations; the checker remains enabled for the test target.

## Validation

- strict Clang-Tidy 18 CMake target on the library and unit tests
- Debug Clang 18 build and unit tests
- Release GCC build and unit tests