### PR TITLE
Group CodeQL Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,15 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
+      # Check for updates to GitHub Actions daily, but only surface them
+      # after the cooldown below has elapsed.
       interval: "daily"
+    # Wait 7 days after a new release is published before opening an update
+    # PR, to reduce the supply-chain risk of pulling in a freshly tagged
+    # (and potentially compromised) release.
     cooldown:
-      default-days: 5
+      default-days: 7
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action*"


### PR DESCRIPTION
## Summary
- batch `github/codeql-action*` version updates into one Dependabot pull request
- align the GitHub Actions cooldown with CCF and merklecpp at seven days

## Testing
- Not run (configuration-only change)